### PR TITLE
`SuperVolt`: Add handling for certain BMSs that send the response in chunks

### DIFF
--- a/bmslib/models/supervolt.py
+++ b/bmslib/models/supervolt.py
@@ -47,13 +47,27 @@ class SuperVoltBt(BtBms):
         self.chargeNumber = None
 
     def _notification_handler(self, sender, data):
+        """
+        Notification handler for the battery
+        It has special handling for the data received from the battery
+        Some SuperVolt batteries send the data in multiple chunks, so we need to combine them
+        """
         if self.verbose_log:
             self.logger.info("notification: {} {}".format(data.hex(), sender))
         if data is not None:
-            self.data = data
-            self.parseData(data)
-            self.lastUpdatetime = time.time()
-        self.notificationReceived = True
+            # ':' is the start of a new data set
+            if data[0] == ord(':'):
+                self.data = data
+            else:
+                self.data += data
+            # Check if self.data is complete, it should start with ':' and end with '~'
+            if self.data[0] == ord(':') and data[-1] == ord('~'):
+                self.parseData(self.data)
+                self.lastUpdatetime = time.time()
+                self.notificationReceived = True
+        else:
+            self.data = None
+            self.notificationReceived = True
 
     async def waitForNotification(self, timeS: float) -> bool:
         start = time.time()


### PR DESCRIPTION
## Problem
We have two SuperVolt batteries in use. With battery 1 this addon worked just fine. With battery 2 it did not work and gave an error saying something along the lines of "Invalid length: 20".
While developing my own program to read the SuperVolt batteries I encountered the same issue and after some debugging and contacting SuperVolt customer support found out that certain SuperVolt batteries do not send the response as a single string, but in multiple chunks:
```
Write: :000250000E03~
Read: :0182500080000101C00
Read: 000880CC80CC90CC80CC
Read: 80000000000000000000
Read: 00000000000000000000
Read: 000000000000000B8404
Read: 24242F002000000008F0
Read: 08F423F~
```
Instead of:
```
Write: :000250000E03~
Read: :0082500080000101C00000880CCB0CCB0CCC0CCA000000000000000000000000000000000000000000000000000000A4402A2A2AF002000000001900193022~
```

## Solution
To fix this I adapted the _notification_handler in `supervolt.py` to now check if the received string is complete and if not piece it together each time a new chunk comes in.
Checking if the response is simply done by checking if it starts with a colon and ends with a tilde.
I also added a comment about this behavior to document this rare behavior and why this handling is needed.

## Testing
We tested this on a Raspberry Pi 4 and verified that both batteries now work as expected with this addon.