### PR TITLE
Pip install into venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ RUN apk add git
 #COPY requirements.txt requirements.txt
 COPY . .
 
-RUN pip3 install -r requirements.txt
+RUN python3 -m venv venv && \
+    . ./venv/bin/activate && \
+    python -m pip install -r requirements.txt
 RUN chmod a+x addon_main.sh
 
 CMD [ "./addon_main.sh" ]

--- a/addon_main.sh
+++ b/addon_main.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/with-contenv bashio
 
-python3 install_bleak.py
+. /app/venv/bin/activate
+
+python install_bleak.py
 
 
 MQTT_HOST=$(bashio::services mqtt "host")


### PR DESCRIPTION
I believe the Home Assistant addon base image was changed to prevent pip installs into the system area. This patch creates a venv to use for pip installing python packages and changes the addon_main.sh script to run within that venv.