### PR TITLE
fix issue #195 caused by paho 2.0.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -232,7 +232,7 @@ async def main():
 
         logger.info('connecting mqtt %s@%s', user_config.mqtt_user, user_config.mqtt_broker)
         # paho_monkey_patch()
-        mqtt_client = paho.Client()
+        mqtt_client = paho.Client(paho.CallbackAPIVersion.VERSION1)
         mqtt_client.enable_logger(logger)
         if user_config.get('mqtt_user', None):
             mqtt_client.username_pw_set(user_config.mqtt_user, user_config.mqtt_password)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ git+https://github.com/jpeters-ml/bleak@feature/windowsPairing
 
 # bleak==0.20.2 # (installed with install_bleak.py)
 
-paho-mqtt
+paho-mqtt>=2.0.0
 backoff
 crcmod
 


### PR DESCRIPTION
This fixes the issue in the simplest possible way - simply by adding the `paho.CallbackAPIVersion.VERSION1` argument.
I don't know what the callback api is all about or if we can move to version2, but this gets it working again without any hassle.
I've also pinned the paho-mqtt package to >=2.0.0 