### PR TITLE
Publishing aggregated metrics when in standalone mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -182,8 +182,10 @@ async def main():
 
     # import env vars from addon_main.sh
     for k, en in dict(mqtt_broker='MQTT_HOST', mqtt_user='MQTT_USER', mqtt_password='MQTT_PASSWORD').items():
-        if not user_config.get(k) and os.environ.get(en):
-            user_config[k] = os.environ[en]
+        env_value = os.environ.get(en)
+        if env_value is not None or k not in user_config:
+            logger.info(f"Setting {k} to user_config: {env_value}")
+            user_config[k] = env_value
 
     if user_config.get('mqtt_broker'):
         port_idx = user_config.mqtt_broker.rfind(':')


### PR DESCRIPTION
Background: HA promotes the creation of a single topic per metric. This can result cumbersome to consume for other application. This PR introduces a `$STANDALONE` environment variable based on which topics are either split (original implementation) or aggregated.

- Add a `$STANDALONE` environment variable
- When the variable is set to a truthy value, aggregate metrics into four common topics:
  - `{device_name}/sample`
  - `{device_name}/cell_voltages`
  - `{device_name}/temperatures`
  - `{device_name}/meter`