### PR TITLE
Fix detection of new JK firmware (32 cells)

### DIFF
--- a/bmslib/models/jikong.py
+++ b/bmslib/models/jikong.py
@@ -191,7 +191,10 @@ class JKBt(BtBms):
     def _decode_sample(self, buf: bytearray, t_buf: float) -> BmsSample:
         buf_set, t_set = self._resp_table[0x01]
 
-        is_new_11fw = buf[189] in {0x0, 0x1} and buf[189 + 32] > 0  # 32 cell version
+        # old fw: field "Nominal_Capacity" starts at buf[146], new fw buf[146] == 0
+        # new fw: field "Nominal_Capacity" starts at buf[178], old fw buf[178] == 0
+        is_new_11fw = buf[178] > 0 and buf[146] == 0
+
         offset = 0
         if is_new_11fw:
             offset = 32


### PR DESCRIPTION
Change detection of new JK firmware (32 cells).

Checking buf[189] is wrong: ,this is the most significant byte of field "Cycle Capacity" and this field will slowly increase in value.

Now we check the least significant byte of field "Nominal Capacity", which is a static field.
This field has value 0 in other fw version.

Fixes issues #209 , #235 , #265 