### PR TITLE
Fix IndexError in _buffer_crc_check when buffer shorter than MIN_RESPONSE_SIZEImplement buffer length guard in CRC check

### DIFF
--- a/bmslib/models/jikong.py
+++ b/bmslib/models/jikong.py
@@ -82,6 +82,13 @@ class JKBt(BtBms):
         self._has_float_charger = None # used for the `float_charge` switch
 
     def _buffer_crc_check(self):
+        # Guard: if buffer is shorter than expected, don't index into it.
+        # This can happen when _notification_handler slices the buffer to the
+        # position of a HEADER and calls us again — the tail may be < MIN_RESPONSE_SIZE.
+        # Without this check, self._buffer[MIN_RESPONSE_SIZE - 1] raises IndexError
+        # inside the bleak notify callback, which tears down the BLE event loop.
+        if len(self._buffer) < MIN_RESPONSE_SIZE:
+            return False
         crc_comp = calc_crc(self._buffer[0:MIN_RESPONSE_SIZE - 1])
         crc_expected = self._buffer[MIN_RESPONSE_SIZE - 1]
         if crc_comp != crc_expected:
@@ -429,7 +436,7 @@ async def main():
 
             # new_state = not s.switches['charge']
             # await bms.set_switch('charge', new_state)
-            # await bms._q(cmd=0x96, resp= 0x01)
+            # await self._q(cmd=0x96, resp= 0x01)
             # print('set charge', new_state)
             # await asyncio.sleep(4)
             # s = await bms.fetch(wait=True)


### PR DESCRIPTION
.When _notification_handler slices the buffer to a HEADER position and calls
_buffer_crc_check() a second time, the remaining tail can be shorter than
MIN_RESPONSE_SIZE. Without a length guard, self._buffer[MIN_RESPONSE_SIZE - 1]
raises IndexError inside the bleak notify callback, which tears down the BLE
event loop and causes the "disconnected after ~10s" symptom.

Fix: add an early return False if len(self._buffer) < MIN_RESPONSE_SIZE.

Tested on JK BMS with batmon-ha addon v1.98d on Home Assistant.