### PR TITLE
Validate JBD response frames before decoding

### DIFF
--- a/bmslib/models/jbd.py
+++ b/bmslib/models/jbd.py
@@ -22,6 +22,48 @@ def _jbd_command(command: int):
     return bytes([0xDD, 0xA5, command, 0x00, 0xFF, 0xFF - (command - 1), 0x77])
 
 
+def _validate_jbd_response(frame: bytes, expected_command: int = None) -> bytes:
+    """Validate a complete JBD response and return its payload.
+
+    Cell values are intentionally not range-checked here. A structurally valid
+    frame reporting 0 mV may represent a real, safety-critical cell fault and
+    must reach the caller unchanged.
+    """
+    if len(frame) < 7:
+        raise ValueError("JBD response is shorter than the minimum frame size")
+    if frame[0] != 0xDD:
+        raise ValueError("JBD response has an invalid header")
+
+    command = frame[1]
+    if expected_command is not None and command != expected_command:
+        raise ValueError(
+            f"JBD response command mismatch: expected 0x{expected_command:02x}, "
+            f"got 0x{command:02x}"
+        )
+
+    payload_length = frame[3]
+    expected_length = payload_length + 7  # header(4) + checksum(2) + terminator(1)
+    if len(frame) != expected_length:
+        raise ValueError(
+            f"JBD response length mismatch: expected {expected_length} bytes, "
+            f"got {len(frame)}"
+        )
+    if frame[-1] != 0x77:
+        raise ValueError("JBD response has an invalid terminator")
+    if frame[2] != 0:
+        raise ValueError(f"JBD command 0x{command:02x} failed with status 0x{frame[2]:02x}")
+
+    received_checksum = int.from_bytes(frame[-3:-1], "big")
+    calculated_checksum = (0x10000 - sum(frame[2:-3])) & 0xFFFF
+    if received_checksum != calculated_checksum:
+        raise ValueError(
+            f"JBD response checksum mismatch: expected 0x{calculated_checksum:04x}, "
+            f"got 0x{received_checksum:04x}"
+        )
+
+    return frame[4:-3]
+
+
 class JbdBt(BtBms):
     UUID_RX = '0000ff01-0000-1000-8000-00805f9b34fb'
     UUID_TX = '0000ff02-0000-1000-8000-00805f9b34fb'
@@ -34,18 +76,36 @@ class JbdBt(BtBms):
         self._last_response = None
 
     def _notification_handler(self, sender, data):
-
-        # print("bms msg {0}: {1}".format(sender, data))
         self._buffer += data
 
-        if self._buffer.endswith(b'w'):
-            command = self._buffer[1]
-            buf = self._buffer[:]
-            self._buffer.clear()
+        while self._buffer:
+            # Discard noise before the next JBD header, but retain a partial frame.
+            header = self._buffer.find(0xDD)
+            if header < 0:
+                self.logger.warning("discarding %d bytes without a JBD header", len(self._buffer))
+                self._buffer.clear()
+                return
+            if header:
+                self.logger.warning("discarding %d bytes before JBD header", header)
+                del self._buffer[:header]
+            if len(self._buffer) < 4:
+                return
 
-            # print(command, 'buffer endswith w', self._buffer)
-            self._last_response = buf
-            self._fetch_futures.set_result(command, buf)
+            frame_length = self._buffer[3] + 7
+            if len(self._buffer) < frame_length:
+                return
+
+            frame = bytes(self._buffer[:frame_length])
+            del self._buffer[:frame_length]
+            try:
+                _validate_jbd_response(frame)
+            except ValueError as exc:
+                self.logger.warning("discarding invalid JBD response: %s", exc)
+                continue
+
+            command = frame[1]
+            self._last_response = frame
+            self._fetch_futures.set_result(command, frame)
 
     async def connect(self, **kwargs):
         await super().connect(**kwargs)
@@ -70,8 +130,8 @@ class JbdBt(BtBms):
         # binary reading
         #  https://github.com/NeariX67/SmartBMSUtility/blob/main/Smart%20BMS%20Utility/Smart%20BMS%20Utility/BMSData.swift
 
-        buf = await self._q(cmd=0x03)
-        buf = buf[4:]
+        frame = await self._q(cmd=0x03)
+        buf = _validate_jbd_response(frame, expected_command=0x03)
 
         num_cell = int.from_bytes(buf[21:22], 'big')
         num_temp = int.from_bytes(buf[22:23], 'big')
@@ -126,10 +186,11 @@ class JbdBt(BtBms):
         return sample
 
     async def fetch_voltages(self):
-        buf = await self._q(cmd=0x04)
-        num_cell = int(buf[3] / 2)
-        voltages = [(int.from_bytes(buf[4 + i * 2:i * 2 + 6], 'big')) for i in range(num_cell)]
-        return voltages
+        frame = await self._q(cmd=0x04)
+        payload = _validate_jbd_response(frame, expected_command=0x04)
+        if len(payload) % 2:
+            raise ValueError(f"JBD cell-voltage payload has odd length {len(payload)}")
+        return [int.from_bytes(payload[i:i + 2], 'big') for i in range(0, len(payload), 2)]
 
     async def set_switch(self, switch: str, state: bool):
 

--- a/bmslib/test/test_jbd_decode.py
+++ b/bmslib/test/test_jbd_decode.py
@@ -40,6 +40,58 @@ def _jbd_frame(jbd_current, charge_ah=100.0, capacity_ah=100.0, num_temp=0):
     return frame
 
 
+def _jbd_voltage_frame(voltages):
+    payload = b''.join(voltage.to_bytes(2, 'big') for voltage in voltages)
+    frame = bytes([0xDD, 0x04, 0x00, len(payload)]) + payload
+    checksum = (0x10000 - sum(frame[2:])) & 0xFFFF
+    return frame + checksum.to_bytes(2, 'big') + bytes([0x77])
+
+
+def _fetch_voltages(bms, frame):
+    async def fake_q(*a, **kw):
+        return frame
+    bms._q = fake_q
+    return asyncio.run(bms.fetch_voltages())
+
+
+def test_jbd_voltage_decode_preserves_valid_zero_cell_reading():
+    """A real zero in an intact, checksum-valid frame must never be hidden."""
+    bms = JbdBt("00:11:22:33:44:55", name="jbd")
+    assert _fetch_voltages(bms, _jbd_voltage_frame([3301, 0, 3299])) == [3301, 0, 3299]
+
+
+def test_jbd_voltage_decode_rejects_truncated_frame_instead_of_fabricating_zeros():
+    bms = JbdBt("00:11:22:33:44:55", name="jbd")
+    complete = _jbd_voltage_frame([3300 + i for i in range(13)])
+    # Retain the declared 26-byte payload length but simulate receipt ending
+    # after cell 8. The old decoder returned five fabricated zero values.
+    truncated = complete[:4 + 8 * 2] + bytes([0x77])
+
+    with pytest.raises(ValueError, match="length mismatch"):
+        _fetch_voltages(bms, truncated)
+
+
+def test_jbd_voltage_decode_rejects_bad_checksum():
+    bms = JbdBt("00:11:22:33:44:55", name="jbd")
+    frame = bytearray(_jbd_voltage_frame([3300, 3301]))
+    frame[4] ^= 0x01
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        _fetch_voltages(bms, bytes(frame))
+
+
+def test_jbd_notification_waits_for_declared_frame_length_even_if_fragment_ends_in_77():
+    bms = JbdBt("00:11:22:33:44:55", name="jbd")
+    frame = _jbd_voltage_frame([3300 + i for i in range(13)])
+    fragment = frame[:4 + 8 * 2]
+    fragment = fragment[:-1] + bytes([0x77])  # terminator-like payload byte
+
+    bms._notification_handler(None, fragment)
+
+    assert bytes(bms._buffer) == fragment
+    assert bms._last_response is None
+
+
 def _fetch(bms, frame):
     """fetch() then the sampler's runtime derivation, mirroring BmsSampler.
 


### PR DESCRIPTION
## Summary

Prevent the native JBD connector from decoding and publishing incomplete or corrupted response frames.

## Problem

The notification handler previously treated any accumulated buffer ending in `0x77` as a complete response. `fetch_voltages()` then decoded the number of cells declared by the payload-length byte even when bytes for later cells were missing.

Because `int.from_bytes(b"", "big")` returns zero, missing cell data could be published as fabricated zero-voltage readings.

## Changes

- Determine completion using the declared JBD payload length.
- Validate header, command, status, frame length, checksum, and terminator.
- Reject odd-length cell-voltage payloads.
- Preserve every value from valid frames, including a legitimate 0 mV cell.
- Add regression tests for truncated responses, invalid checksums, notification fragments ending in `0x77`, and valid frames containing a zero-voltage cell.

## Testing

`bmslib/test/test_jbd_decode.py`: 16 tests passed.

Closes #388