### PR TITLE
Publish explicit 0 instead of dropping None problem/problem_code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Shell/entrypoint scripts must stay LF - they run inside the Alpine/HA-add-on
+# base image via a shebang (#!/bin/sh, #!/usr/bin/with-contenv bashio). A CRLF
+# checkout (e.g. Windows git core.autocrlf=true) corrupts the shebang line
+# itself, and the container fails to start with either "not found" (interpreter
+# path literally includes \r) or "no such file or directory" (exec can't
+# resolve the mangled shebang at all) - neither error mentions line endings,
+# so this is easy to lose time to on a Windows checkout without this rule.
+*.sh text eol=lf

--- a/bmslib/bt.py
+++ b/bmslib/bt.py
@@ -1,5 +1,4 @@
 import asyncio
-import fcntl
 import logging
 import math
 import os
@@ -261,6 +260,7 @@ def _hci_dev_info(dev_id: int) -> Optional[dict]:
     """
     if not sys.platform.startswith('linux'):
         return None
+    import fcntl
     if not hasattr(socket, 'AF_BLUETOOTH'):
         socket.AF_BLUETOOTH = 31  # type: ignore[attr-defined]
     if not hasattr(socket, 'BTPROTO_HCI'):

--- a/bmslib/mqtt_util.py
+++ b/bmslib/mqtt_util.py
@@ -261,11 +261,16 @@ def publish_sample(client, device_topic, sample: BmsSample):
             topic = f"{device_topic}/switch/{switch_name}"
             mqtt_single_out(client, topic, 'ON' if switch_state else 'OFF')
 
-    if sample.problem is not None:
-        mqtt_single_out(client, f"{device_topic}/problem",
-                        'ON' if sample.problem else 'OFF')
-    if sample.problem_code is not None:
-        mqtt_single_out(client, f"{device_topic}/problem_code", sample.problem_code)
+    # Same fix as sinks.py's publish_sample: aiobmsble reports None (not 0/False)
+    # for "no problem", and skipping the publish entirely on None means a genuine
+    # clear is never sent - HA's sensor just holds the last real problem_code
+    # forever with no way to tell "still true" from "went stale". Publish an
+    # explicit healthy value instead of skipping, so a real clear is a real,
+    # visible MQTT message.
+    mqtt_single_out(client, f"{device_topic}/problem",
+                    'ON' if sample.problem else 'OFF')
+    mqtt_single_out(client, f"{device_topic}/problem_code",
+                    sample.problem_code if sample.problem_code is not None else 0)
 
     if sample.battery_charging is not None:
         mqtt_single_out(client, f"{device_topic}/battery_charging",

--- a/bmslib/sinks.py
+++ b/bmslib/sinks.py
@@ -128,6 +128,20 @@ class InfluxDBSink(BmsSampleSink):
 
     def publish_sample(self, bms_name, sample: BmsSample, tags=None):
         fields = flatten({**sample.values(), "timestamp": None})
+        # problem/problem_code are bitmask/status fields where aiobmsble reports
+        # None for "no problem" rather than 0. remove_none_values() below drops
+        # any None field outright, which silently erases a genuine clear - a
+        # transition from e.g. 131072 back to "no problem" becomes indistinguishable
+        # from "not sampled this round" to every downstream consumer (InfluxDB, MQTT,
+        # HA). Once a real problem fires, its last non-None value then sits there
+        # forever with no way to tell "still true" from "went stale", since nothing
+        # ever explicitly publishes the clear. Normalize to 0 first (0 == no bits
+        # set, a fully correct "healthy" value, not a lossy placeholder) so the
+        # field is always present and a real clear is a real, visible transition
+        # the equal-value dedup below won't suppress.
+        for k in ('problem', 'problem_code'):
+            if fields.get(k) is None:
+                fields[k] = 0
         remove_none_values(fields)
         for k, v in fields.items():
             if isinstance(v, int):


### PR DESCRIPTION
## Summary

- `bmslib/mqtt_util.py` and `bmslib/sinks.py` both skip publishing `problem`/`problem_code` entirely when the value is `None` (aiobmsble's convention for "no active problem", rather than `0`/`False`). Since a genuine clear looks identical to "not sampled this round" to every downstream consumer, once a real problem fires, its last non-`None` value sits there forever with no way to tell "still true" from "went stale" - no message ever explicitly signals the clear.
- Confirmed live: a Seplos pack's Alarm-category `problem_code` (bit 17, "Intermittent charging function") stayed latched in Home Assistant for 20+ minutes of continuous healthy sampling after the underlying condition had actually cleared, because nothing ever published the transition back to healthy.
- Fix: normalize `None` to `0` before either sink's None-filtering runs. `0` == no bits set is a fully correct "healthy" value, not a lossy placeholder, so this makes a real clear a real, visible transition in both MQTT and InfluxDB output.

Also included on this branch (small, unrelated-but-useful):
- `.gitattributes`: force LF on `*.sh` - a CRLF checkout (e.g. Windows `git config core.autocrlf=true`) corrupts the shebang line in `entrypoint.sh`/`addon_main.sh`, and the container then fails to start with an error that never mentions line endings (`exec ...: not found` or `no such file or directory` depending on which layer trips on the stray `\r`). Cost real time to a fresh Windows checkout twice in one afternoon before adding this.
- `bmslib/bt.py`: defer the Unix-only `fcntl` import to inside `_hci_dev_info()`, which already returns early on non-Linux platforms before touching it. Lets the module import cleanly for local dev/tooling on Windows without affecting the normal Linux runtime path at all.

Happy to split the unrelated commits into separate PRs if preferred - flagging here in case that's cleaner for review.

## Test plan

- Rebuilt standalone (`docker build --build-arg BUILD_FROM=alpine:3.21`), redeployed against 3 real Seplos packs via ESPHome Bluetooth proxies.
- Confirmed via Home Assistant: `problem_code` transitioned from a stale latched value to an explicit `0`, with a fresh timestamp matching the actual sample that cleared it - previously this transition was invisible.
- Confirmed normal operation otherwise unaffected (voltage/current/SoC/etc. all sampling and publishing as before).