### PR TITLE
sampling: raise fetch_loop's error backoff cap 60s -> 10min

### DIFF
--- a/bmslib/sampling.py
+++ b/bmslib/sampling.py
@@ -37,6 +37,21 @@ BT_POWER_CYCLE_MIN_INTERVAL = 600
 BT_POWER_CYCLE_SETTLE = 3  # seconds the controller stays down / gets to come back up
 _t_last_bt_power_cycle = 0.0
 
+# fetch_loop's per-cycle error backoff ceiling. Was a flat 60s regardless of how many
+# consecutive failures had piled up - fine for a transient blip, but a *permanently*
+# broken device (dead battery/balancer BMS, no software fix possible until physically
+# replaced) then retries forever on a fixed ~60s cadence with no further backoff.
+# Confirmed live on a shared ble_stack: esphome deployment (6 devices, 3 ESP32
+# Bluetooth proxies): a chronically-failing device's repeated connection attempts
+# visibly starved a proxy of scan time for its *other* devices (captured via the
+# proxy's own VERY_VERBOSE BLE stack log - a GATT connect attempt to the broken
+# device was in progress while zero advertisements arrived from anything else that
+# proxy would otherwise reliably hear), on top of the more obvious connection-slot
+# contention. Raising the ceiling to 10 minutes still notices a device coming back
+# reasonably quickly, while cutting a permanently-broken device's contention with its
+# healthy neighbors roughly 10x.
+FETCH_ERROR_BACKOFF_CAP = 600
+
 
 async def bt_power_cycle(bms_name):
     """Power the bluetooth controller(s) off and on, last-resort recovery for a
@@ -685,5 +700,5 @@ async def fetch_loop(fn, period, max_errors, should_stop=None):
             if max_errors and num_errors_row > max_errors:
                 logger.warning('too many errors, abort')
                 break
-            await asyncio.sleep(min(1.1 ** num_errors_row, 60))
+            await asyncio.sleep(min(1.1 ** num_errors_row, FETCH_ERROR_BACKOFF_CAP))
         await asyncio.sleep(period)


### PR DESCRIPTION
## Summary

`fetch_loop`'s consecutive-error backoff (`min(1.1 ** num_errors_row, 60)`) caps at a flat 60 seconds regardless of how many consecutive failures have piled up. That's reasonable for a transient blip, but a *permanently* broken device (dead BMS/balancer, no software fix possible until physically replaced) then retries forever on a fixed ~60s cadence with no further backoff - `1.1**44` already exceeds the old 60s cap, so anything past ~44 lifetime errors just sits there.

On a shared `ble_stack: esphome` deployment (multiple devices behind one ESP32 Bluetooth proxy), this isn't just wasted effort against a device that's never coming back - it's real, measurable contention with that device's healthy neighbors sharing the same proxy.

Confirmed live on our own deployment (3 packs + 3 balancers, one balancer with a known dead NEEY unit, all going through shared ESP32 proxies): captured a proxy's own `VERY_VERBOSE` BLE stack log while the broken device's GATT connect attempt was in progress, and zero advertisements arrived from anything else that same proxy otherwise hears reliably during that window - on top of the more obvious connection-slot contention from the repeated connect attempts themselves (`BleakOutOfConnectionSlotsError` on a *different* device sharing the proxy, while the broken device was mid-retry).

## Fix

Raise the backoff ceiling from 60s to 10 minutes (`FETCH_ERROR_BACKOFF_CAP`, named module-level constant next to the existing `BT_POWER_CYCLE_MIN_INTERVAL`). Still notices a device recovering reasonably quickly (the `1.1**n` growth curve is unchanged for the first several dozen failures), while cutting a permanently-broken device's contention with everything sharing its proxy by roughly 10x once it's clearly not transient.

## Test plan

- Reproduced the contention live via the proxy's own verbose BLE log (see summary above).
- Confirmed the fix doesn't change behavior for devices with a small number of consecutive errors (backoff curve identical below the old 60s threshold).
- Deployed against the real 6-device/3-proxy setup described above; the known-dead balancer no longer retries every ~60s indefinitely.