### PR TITLE
sampling: periodic reconnect to re-evaluate BLE proxy path, jittered

### DIFF
--- a/bmslib/bt.py
+++ b/bmslib/bt.py
@@ -716,7 +716,17 @@ class BtBms:
 
         await scanner.stop()
 
-    async def disconnect(self):
+    async def disconnect(self, reset: bool = False):
+        """Disconnect. reset=True uses _force_disconnect() (below) instead of the
+        plain client.disconnect() - the thorough, bounded teardown already built for
+        this exact situation (see its own docstring), for a caller forcing a
+        disconnect *outside* of connect()'s own reconnect flow (e.g. periodic
+        connection-path re-evaluation) that has no guarantee anything will clean up
+        after it otherwise.
+        """
+        if reset:
+            await self._force_disconnect()
+            return
         self._connect_complete = False
         self._in_disconnect = True
         await self.client.disconnect()

--- a/bmslib/models/BLE_BMS_wrap.py
+++ b/bmslib/models/BLE_BMS_wrap.py
@@ -192,9 +192,28 @@ class BMS():
         #    await self._connect_with_scanner(timeout=timeout)
         # await self.start_notify(self.CHAR_UUID, self._notification_handler)
 
-    async def disconnect(self):
-        if self.ble_bms is not None:
+    async def disconnect(self, reset: bool = False):
+        """Disconnect. reset=True does the same thorough cleanup connect() itself
+        does before replacing a stale instance (see the big comment in connect()):
+        releases the notify FD, runs bleak-retry-connector's close_stale_connections
+        to drop any lingering BlueZ link, bounded by the same 10s timeout so a wedged
+        BlueZ can't hang the caller forever, and clears self.ble_bms so the object is
+        left exactly as if it had never connected (a plain reset=False disconnect
+        leaves the old instance referenced, which connect() would still clean up
+        properly on its own next call - but a caller forcing a disconnect *outside*
+        of connect(), e.g. for periodic connection-path re-evaluation, has no such
+        follow-up guarantee unless it asks for the thorough version explicitly).
+        """
+        if self.ble_bms is None:
+            return
+        if not reset:
             await self.ble_bms.disconnect()
+            return
+        try:
+            await asyncio.wait_for(self.ble_bms.disconnect(reset=True), timeout=10)
+        except Exception as e:
+            logger.warning('%s: reset disconnect failed: %s', self.name, str(e) or type(e).__name__)
+        self.ble_bms = None
 
     async def set_switch(self, switch: str, state: bool):
         # aiobmsble has no switch-write API — surface mosfet states as read-only.

--- a/bmslib/sampling.py
+++ b/bmslib/sampling.py
@@ -150,7 +150,8 @@ class BmsSampler:
                  current_calibration_factor=1.0,
                  over_power=None,
                  bms_group: Optional[BmsGroup] = None,
-                 bt_power_cycle_on_error=False
+                 bt_power_cycle_on_error=False,
+                 reconnect_interval_s: Optional[float] = None,
                  ):
 
         self.bms = bms
@@ -184,6 +185,23 @@ class BmsSampler:
         self._time_next_retry = 0
         self._last_diag_t = 0
         self.bt_power_cycle_on_error = bt_power_cycle_on_error
+
+        # Periodic reconnect for connection-path re-evaluation (#opt-in, see
+        # reconnect_interval_minutes in config.yaml). keep_alive holds a device on
+        # whichever backend/proxy it first connected through for the rest of the
+        # session - habluetooth's own connect() returns immediately if already
+        # connected and never re-scores available backends on its own (confirmed by
+        # reading habluetooth/wrappers.py directly - _async_get_best_available_backend_
+        # and_device() only ever runs from inside connect()). On a multi-proxy
+        # ble_stack: esphome deployment this "sticky first connect" is provably
+        # suboptimal: two restarts of the same fleet ~15 minutes apart, with nothing
+        # about the devices' physical placement changed, produced two completely
+        # different "best" proxy assignments - whichever proxy happened to answer
+        # first/fastest at connect time won, not necessarily the best-scoring one long
+        # term. This periodically forces a clean disconnect so the next cycle's normal
+        # reconnect flow gets a fresh, current best-backend evaluation.
+        self._reconnect_interval_s = reconnect_interval_s
+        self._last_connect_time = 0.0
 
         self.algorithm = None
         if algorithms:
@@ -333,6 +351,15 @@ class BmsSampler:
         bms = self.bms
         mqtt_client = self.mqtt_client
 
+        if (self._reconnect_interval_s and bms.is_connected
+                and time.time() - self._last_connect_time > self._reconnect_interval_s):
+            logger.info('%s periodic reconnect for path re-evaluation (%.0fs since last connect)',
+                        bms.name, time.time() - self._last_connect_time)
+            try:
+                await bms.disconnect()
+            except Exception as e:
+                logger.warning('%s periodic reconnect: disconnect failed: %s', bms.name, e)
+
         was_connected = bms.is_connected
 
         # if not was_connected:
@@ -358,6 +385,7 @@ class BmsSampler:
 
             if not was_connected:
                 logger.info('connected bms %s!', bms)
+                self._last_connect_time = time.time()
 
             if self.device_info is None and self.num_samples == 0:
                 # try to fetch device info first. if bms.fetch() fails we might have at least some details

--- a/bmslib/sampling.py
+++ b/bmslib/sampling.py
@@ -257,7 +257,13 @@ class BmsSampler:
     def _jittered_interval(self):
         """+/-20% jitter on the configured reconnect_interval_s - see the big comment
         on self._reconnect_interval_s in __init__ for why this needs to be re-rolled
-        on every cycle rather than fixed once per device."""
+        on every cycle rather than fixed once per device. Called unconditionally from
+        __init__ (and again after every periodic reconnect) regardless of whether the
+        feature is enabled, so it must tolerate reconnect_interval_s being None/0 -
+        the _sample_inner() check that actually uses the result already short-circuits
+        on `self._reconnect_interval_s and ...` first, so a None here is never read."""
+        if not self._reconnect_interval_s:
+            return None
         return self._reconnect_interval_s * random.uniform(0.8, 1.2)
 
     async def __call__(self):

--- a/bmslib/sampling.py
+++ b/bmslib/sampling.py
@@ -200,7 +200,25 @@ class BmsSampler:
         # first/fastest at connect time won, not necessarily the best-scoring one long
         # term. This periodically forces a clean disconnect so the next cycle's normal
         # reconnect flow gets a fresh, current best-backend evaluation.
+        #
+        # JITTER (added 2026-09-02, same day, after live-testing the un-jittered version):
+        # every device in a fleet that all connected within the same narrow startup window
+        # stays locked in that same relative timing forever with a *fixed* interval - so
+        # every cycle, most of the fleet's forced reconnects land within a 1-2 minute span
+        # of each other instead of spreading across the full interval. Confirmed live this
+        # is not just cosmetic: cycle 3 of a 3-cycle test (10-minute interval) put 4 of 5
+        # devices into simultaneous reconnect attempts, and the proxies serving them
+        # degraded into repeatedly reporting "not scanning" across all of them at once -
+        # requiring a full proxy reboot to clear, the same failure signature seen from
+        # unrelated causes earlier in that session. The individual reconnect mechanism
+        # itself (reset=True) was not the problem - every reconnect that fired eventually
+        # either succeeded quickly or self-recovered; it was the *simultaneity* that
+        # degraded the shared proxy hardware. Re-rolling a random +/-20% jitter on every
+        # cycle (not just once at startup) means even an unlucky coincidence self-corrects
+        # on the very next cycle, rather than two devices' offsets staying pinned together
+        # forever if they ever happen to land close.
         self._reconnect_interval_s = reconnect_interval_s
+        self._next_reconnect_interval_s = self._jittered_interval()
         self._last_connect_time = 0.0
 
         self.algorithm = None
@@ -235,6 +253,12 @@ class BmsSampler:
 
     def get_meter_state(self):
         return {meter.name: dict(reading=meter.get()) for meter in self.meters}
+
+    def _jittered_interval(self):
+        """+/-20% jitter on the configured reconnect_interval_s - see the big comment
+        on self._reconnect_interval_s in __init__ for why this needs to be re-rolled
+        on every cycle rather than fixed once per device."""
+        return self._reconnect_interval_s * random.uniform(0.8, 1.2)
 
     async def __call__(self):
         self._num_errors += 1
@@ -352,9 +376,9 @@ class BmsSampler:
         mqtt_client = self.mqtt_client
 
         if (self._reconnect_interval_s and bms.is_connected
-                and time.time() - self._last_connect_time > self._reconnect_interval_s):
-            logger.info('%s periodic reconnect for path re-evaluation (%.0fs since last connect)',
-                        bms.name, time.time() - self._last_connect_time)
+                and time.time() - self._last_connect_time > self._next_reconnect_interval_s):
+            logger.info('%s periodic reconnect for path re-evaluation (%.0fs since last connect, jittered target %.0fs)',
+                        bms.name, time.time() - self._last_connect_time, self._next_reconnect_interval_s)
             # reset=True: the plain disconnect() (no reset) does NOT run the same
             # notify-FD/stale-BlueZ-link cleanup connect() itself does before
             # replacing an old instance - confirmed live (#periodic-reconnect
@@ -395,6 +419,7 @@ class BmsSampler:
             if not was_connected:
                 logger.info('connected bms %s!', bms)
                 self._last_connect_time = time.time()
+                self._next_reconnect_interval_s = self._jittered_interval()
 
             if self.device_info is None and self.num_samples == 0:
                 # try to fetch device info first. if bms.fetch() fails we might have at least some details

--- a/bmslib/sampling.py
+++ b/bmslib/sampling.py
@@ -355,8 +355,17 @@ class BmsSampler:
                 and time.time() - self._last_connect_time > self._reconnect_interval_s):
             logger.info('%s periodic reconnect for path re-evaluation (%.0fs since last connect)',
                         bms.name, time.time() - self._last_connect_time)
+            # reset=True: the plain disconnect() (no reset) does NOT run the same
+            # notify-FD/stale-BlueZ-link cleanup connect() itself does before
+            # replacing an old instance - confirmed live (#periodic-reconnect
+            # testing): a plain disconnect() here left a device unable to
+            # reconnect via ANY proxy (BleakOutOfConnectionSlotsError with 0 free
+            # slots everywhere) until the whole container was restarted, exactly
+            # the stale-notify-FD failure mode connect()'s own cleanup exists to
+            # prevent (#384) - this caller just wasn't going through connect()'s
+            # cleanup path at all. reset=True runs that same cleanup explicitly.
             try:
-                await bms.disconnect()
+                await bms.disconnect(reset=True)
             except Exception as e:
                 logger.warning('%s periodic reconnect: disconnect failed: %s', bms.name, e)
 

--- a/config.yaml
+++ b/config.yaml
@@ -63,6 +63,7 @@ options:
   bt_power_cycle: false
   bt_power_cycle_on_error: false
   ble_stack: bleak
+  reconnect_interval_minutes: 240
   # sample_period/publish_period/expire_values_after are kept here (and required
   # in the schema) so they render as normal, always-visible fields. They must NOT
   # live in the collapsed "unused optional configuration options" section: edits
@@ -113,7 +114,7 @@ schema:
   # rate-limited to one cycle per BT_POWER_CYCLE_MIN_INTERVAL (bmslib/sampling.py).
   bt_power_cycle_on_error: "bool?"
 
-  # Opt-in, unset/0 = disabled. With keep_alive on, a device stays on whichever
+  # Defaults to 240 (4h). Unset/0 = disabled. With keep_alive on, a device stays on whichever
   # backend/proxy it first connected through for the rest of the session -
   # habluetooth's own connect() never re-evaluates available backends once
   # connected (confirmed by reading habluetooth/wrappers.py: the best-backend

--- a/config.yaml
+++ b/config.yaml
@@ -113,6 +113,23 @@ schema:
   # rate-limited to one cycle per BT_POWER_CYCLE_MIN_INTERVAL (bmslib/sampling.py).
   bt_power_cycle_on_error: "bool?"
 
+  # Opt-in, unset/0 = disabled. With keep_alive on, a device stays on whichever
+  # backend/proxy it first connected through for the rest of the session -
+  # habluetooth's own connect() never re-evaluates available backends once
+  # connected (confirmed by reading habluetooth/wrappers.py: the best-backend
+  # scoring only ever runs from inside connect() itself). On a multi-proxy
+  # ble_stack: esphome deployment this is provably suboptimal - two restarts of
+  # the same fleet ~15 minutes apart, nothing about physical placement changed,
+  # produced two completely different "best" proxy assignments, because whichever
+  # proxy answered first/fastest at connect time won, not necessarily the
+  # best-scoring one long term. Setting this forces each device to periodically
+  # disconnect and let the normal reconnect flow re-evaluate with current data.
+  # Each forced reconnect costs a real data gap (~4-8s observed) while it
+  # reconnects, so pick an interval that trades that cost against how often your
+  # RF environment/proxy fleet actually changes - minutes for testing/tuning,
+  # hours-to-a-day for steady-state production.
+  reconnect_interval_minutes: "float?"
+
   # "bleak" = stock BlueZ/D-Bus stack (default); "bumble" = bumble-bleak
   # (pure-Python HCI, no BlueZ/D-Bus) which takes exclusive ownership of the
   # adapter(s) it uses (brings them down), so they leave the HA Bluetooth pool;

--- a/main.py
+++ b/main.py
@@ -339,6 +339,8 @@ async def main():
         bms_group=groups_by_bms.get(bms.name),
         sinks=sinks,
         bt_power_cycle_on_error=user_config.get('bt_power_cycle_on_error', False),
+        reconnect_interval_s=(user_config.get('reconnect_interval_minutes') or None) and
+                              user_config['reconnect_interval_minutes'] * 60,
     ) for bms in bms_list]
 
     # move groups to the end


### PR DESCRIPTION
## Summary

With `keep_alive` on, a device stays on whichever proxy/backend it first connected
through for the rest of the session -- habluetooth's own `connect()` never
re-evaluates available backends once connected (confirmed by reading
`habluetooth/wrappers.py`: the best-backend scoring only runs from inside
`connect()` itself). On a multi-proxy `ble_stack: esphome` deployment this is
provably suboptimal: two restarts of the same fleet ~15 minutes apart, with
nothing about physical placement changed, produced two completely different
"best" proxy assignments, because whichever proxy answered first/fastest at
connect time won, not necessarily the best-scoring one long term.

This adds an opt-in `reconnect_interval_minutes` option. When set, each device
periodically performs a graceful `disconnect(reset=True)` (the same thorough
BlueZ/notify-FD cleanup `connect()` already does before replacing a stale
instance -- plain `disconnect()` was tried first and left devices permanently
stuck, since it skips that cleanup) so the normal reconnect flow re-evaluates
proxy/backend choice with current data.

The interval is jittered +/-20% and **re-rolled on every reconnect**, not just
once at startup. Live-tested at a 10-minute interval: with a fixed interval, 5
devices that all first connected within the same ~15s startup window stayed
locked in that window on every later cycle too, and by the 3rd cycle the
simultaneous reconnect burst pushed all 3 proxies into "not scanning"
simultaneously (one device hit 20 consecutive errors, required a full proxy
reboot to recover). With jitter, the same 3-cycle test spread reconnects from
a ~2-4 minute cluster out to as much as 7 minutes of the 10-minute window, and
the 3rd cycle stayed healthy (peak consecutive errors dropped to 4, "not
scanning" rate stayed at baseline, no proxy intervention needed).

Ships with `reconnect_interval_minutes: 240` (4h) as the default, a
steady-state-appropriate interval per the above testing (minutes are
appropriate for tuning/testing, hours-to-a-day for production, per the
schema comment). Set to `0`/unset to disable.

## Test plan

- [x] 3-cycle live test at `reconnect_interval_minutes: 10` without jitter --
      reproduced the clustering/"not scanning" fleet degradation on cycle 3
- [x] Added jitter, re-tested 3 more cycles at the same interval -- no
      degradation, errors stayed low, proxies stayed healthy
- [x] Confirmed `disconnect(reset=True)` doesn't regress the original
      stuck-forever bug across all 6 test cycles
- [x] HA sensor freshness confirmed for all tracked devices throughout testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)